### PR TITLE
Load thruster parameters

### DIFF
--- a/src/GazeboThruster.cpp
+++ b/src/GazeboThruster.cpp
@@ -70,7 +70,7 @@ void GazeboThruster::loadThrusters()
                     thruster.maxThrust = getParameter<double>(thrusterElement,"max_thrust","N",10);
                     thruster.effort = 0.0;
                     thrusters.push_back(thruster);
-                    thrusterElement = pluginElement->GetNextElement("thruster");
+                    thrusterElement = thrusterElement->GetNextElement("thruster");
                 }
             }else
             {

--- a/src/GazeboThruster.cpp
+++ b/src/GazeboThruster.cpp
@@ -1,5 +1,6 @@
 #include "GazeboThruster.hpp"
 
+using namespace std;
 using namespace gazebo;
 using namespace gazebo_thruster;
 
@@ -15,9 +16,10 @@ GazeboThruster::~GazeboThruster()
 void GazeboThruster::Load(physics::ModelPtr _model,sdf::ElementPtr _sdf)
 {
     model = _model;
-    gzmsg << "GazeboThruster: loading thrusters from model: " << model->GetName() << std::endl;
+    gzmsg << "GazeboThruster: loading thrusters from model: " << model->GetName() << endl;
 
-    loadLinks();
+    loadThrusters();
+    checkThrusters();
     initComNode();
 
     eventHandler.push_back(
@@ -26,60 +28,116 @@ void GazeboThruster::Load(physics::ModelPtr _model,sdf::ElementPtr _sdf)
 }
 
 
-void GazeboThruster::loadLinks()
+template <class T>
+T GazeboThruster::getParameter(sdf::ElementPtr thrusterElement,
+        string parameter_name, string dimension, T default_value)
 {
-    // Get all links and look for "thruster" in their names
-    physics::Link_V links = model->GetLinks();
-    for(physics::Link_V::iterator link = links.begin(); link != links.end(); ++link)
+    T var = default_value;
+    if(thrusterElement->HasElement(parameter_name.c_str()))
     {
-        std::string linkName = (*link)->GetName();
-        std::size_t found = linkName.find("thruster::");
-        if( found != std::string::npos )
-        {
-            gzmsg <<"GazeboThruster: found link: " << linkName << std::endl;
-            gzmsg <<"GazeboThruster: JointState element name in ROCK joint input port must match the link name: "
-                    << linkName << std::endl;
-            thrusterOutput.insert( std::make_pair( linkName, 0.0 ) );
-        }
+        var = thrusterElement->Get< T >(parameter_name.c_str());
+        gzmsg << "GazeboThruster: " + parameter_name + ": " << var << " " +
+                dimension  << endl;
+    }else{
+        gzmsg << "GazeboThruster: " + parameter_name + ": using default: "
+                << default_value << " " + dimension << endl;
     }
-    if(thrusterOutput.empty())
+    return var;
+}
+
+
+void GazeboThruster::loadThrusters()
+{
+    // Import all thrusters from a model file (sdf)
+    sdf::ElementPtr modelSDF = model->GetSDF();
+    if (modelSDF->HasElement("plugin"))
     {
-        std::string msg = "GazeboThruster: no thruster link was found in gazebo model: "
-                + model->GetName();
-        gzthrow(msg);
+        sdf::ElementPtr pluginElement = modelSDF->GetElement("plugin");
+        gzmsg << "GazeboThruster: found plugin (filename): " << pluginElement->Get<string>("filename") << endl;
+        gzmsg << "GazeboThruster: found plugin (name): " << pluginElement->Get<string>("name") << endl;
+        if(pluginElement->Get<string>("filename") == "libgazebo_thruster.so")
+        {
+            if(pluginElement->HasElement("thruster"))
+            {
+                sdf::ElementPtr thrusterElement = pluginElement->GetElement("thruster");
+                while(thrusterElement)
+                {
+                    // Check thrusters attributes
+                    Thruster thruster;
+                    thruster.name = thrusterElement->Get<string>("name");
+                    gzmsg << "GazeboThruster: thruster name: " << thruster.name << endl;
+                    thruster.minThrust = getParameter<double>(thrusterElement,"min_thrust","N",-10);
+                    thruster.maxThrust = getParameter<double>(thrusterElement,"max_thrust","N",10);
+                    thruster.effort = 0.0;
+                    thrusters.push_back(thruster);
+                    thrusterElement = pluginElement->GetNextElement("thruster");
+                }
+            }else
+            {
+                string msg = "GazeboThruster: sdf model loads thruster plugin but has no thruster defined.\n";
+                msg += "GazeboThruster: please name the links you want to export as thrusters inside the <plugin> tag: \n";
+                msg += "GazeboThruster: <thruster name='thruster::right'> ";
+                gzthrow(msg);
+            }
+        }
     }
 }
 
+void GazeboThruster::checkThrusters()
+{
+    // Get all links and look for thrusters names in their names
+    physics::Link_V links = model->GetLinks();
+    for(vector<Thruster>::iterator thruster = thrusters.begin(); thruster != thrusters.end(); ++thruster)
+    {
+        bool thrusterFound = false;
+        for(physics::Link_V::iterator link = links.begin(); link != links.end(); ++link)
+        {
+            if(thruster->name == (*link)->GetName())
+                thrusterFound = true;
+        }
+        if(!thrusterFound)
+        {
+            string msg = "GazeboThruster: no link name match the thruster name: " + thruster->name +
+                    " in gazebo model: " + model->GetName();
+            gzthrow(msg);
+        }
+    }
+}
 
 void GazeboThruster::initComNode()
 {
     // Initialize communication node and subscribe to gazebo topic
     node = transport::NodePtr(new transport::Node());
     node->Init();
-    std::string topicName = model->GetName() + "/thrusters";
+    string topicName = model->GetName() + "/thrusters";
     thrusterSubscriber = node->Subscribe("~/" + topicName,&GazeboThruster::readInput,this);
     gzmsg <<"GazeboThruster: create gazebo topic /gazebo/"+ model->GetWorld()->GetName()
-            + "/" + topicName << std::endl;
+            + "/" + topicName << endl;
 }
 
 
 void GazeboThruster::readInput(ThrustersMSG& thrustersMSG)
 {
-    // Read buffer and update output data
+    // Read buffer and update the thruster effort
     for(int i = 0; i < thrustersMSG->thrusters_size(); ++i)
     {
-        const gazebo_thruster::msgs::Thruster& thruster = thrustersMSG->thrusters(i);
-        ThrusterOutput::iterator output = thrusterOutput.find( thruster.name() );
-        if( output != thrusterOutput.end() )
+        bool thrusterFound = false;
+        const gazebo_thruster::msgs::Thruster& thrusterCMD = thrustersMSG->thrusters(i);
+        for(vector<Thruster>::iterator thruster = thrusters.begin();
+                thruster != thrusters.end(); ++thruster)
         {
-            if( thruster.has_raw() )
-                output->second = thrusterMathModel( thruster.raw() );
+            if(thrusterCMD.name() == thruster->name)
+            {
+                thrusterFound = true;
+                if( thrusterCMD.has_raw() )
+                    thruster->effort = thrusterMathModel( thrusterCMD.raw() );
 
-            if( thruster.has_effort() )
-                output->second = thruster.effort();
-        }else{
-            gzmsg << "GazeboThruster: thruster "<< thruster.name() << " not found." << std::endl;
+                if( thrusterCMD.has_effort() )
+                    thruster->effort = thrusterCMD.effort();
+            }
         }
+        if(!thrusterFound)
+            gzmsg << "GazeboThruster: incoming thruster name: "<< thrusterCMD.name() << ", not found." << endl;
     }
 }
 
@@ -94,11 +152,11 @@ double GazeboThruster::thrusterMathModel(double input)
 
 void GazeboThruster::updateBegin(common::UpdateInfo const& info)
 {
-    for(ThrusterOutput::iterator output = thrusterOutput.begin();
-            output != thrusterOutput.end(); ++output)
+    for(vector<Thruster>::iterator thruster = thrusters.begin();
+            thruster != thrusters.end(); ++thruster)
     {
-        physics::LinkPtr link = model->GetLink( output->first );
-        link->AddRelativeForce( math::Vector3(output->second,0,0) );
+        physics::LinkPtr link = model->GetLink( thruster->name );
+        link->AddRelativeForce( math::Vector3(thruster->effort,0,0) );
     }
 }
 

--- a/src/GazeboThruster.hpp
+++ b/src/GazeboThruster.hpp
@@ -33,6 +33,8 @@ namespace gazebo_thruster
         void loadThrusters();
         void initComNode();
         void checkThrusters();
+        void checkThrustLimits(std::vector<Thruster>::iterator thruster);
+        double updateEffort(gazebo_thruster::msgs::Thruster thrusterCMD);
 
         std::vector<gazebo::event::ConnectionPtr> eventHandler;
         gazebo::transport::NodePtr node;

--- a/src/GazeboThruster.hpp
+++ b/src/GazeboThruster.hpp
@@ -20,19 +20,29 @@ namespace gazebo_thruster
         typedef const boost::shared_ptr<const gazebo_thruster::msgs::Thrusters> ThrustersMSG;
         void readInput(ThrustersMSG &thrustersMSG);
 
+        struct Thruster{
+            std::string name;
+            double minThrust;
+            double maxThrust;
+            double effort;
+        };
+
     private:
         void updateBegin(gazebo::common::UpdateInfo const& info);
         double thrusterMathModel(double input);
-        void loadLinks();
+        void loadThrusters();
         void initComNode();
+        void checkThrusters();
 
         std::vector<gazebo::event::ConnectionPtr> eventHandler;
         gazebo::transport::NodePtr node;
         gazebo::transport::SubscriberPtr thrusterSubscriber;
         gazebo::physics::ModelPtr model;
 
-        typedef std::map<std::string,double> ThrusterOutput;
-        ThrusterOutput thrusterOutput;
+        template <typename T>
+        T getParameter(sdf::ElementPtr thrusterElement, std::string parameter_name,
+                std::string dimension, T default_value);
+        std::vector<Thruster> thrusters;
     };
     GZ_REGISTER_MODEL_PLUGIN(GazeboThruster)
 } 

--- a/src/GazeboThruster.hpp
+++ b/src/GazeboThruster.hpp
@@ -30,9 +30,9 @@ namespace gazebo_thruster
     private:
         void updateBegin(gazebo::common::UpdateInfo const& info);
         double thrusterMathModel(double input);
-        void loadThrusters();
+        std::vector<Thruster> loadThrusters();
+        bool checkThrusters( std::vector<Thruster> );
         void initComNode();
-        void checkThrusters();
         void checkThrustLimits(std::vector<Thruster>::iterator thruster);
         double updateEffort(gazebo_thruster::msgs::Thruster thrusterCMD);
 


### PR DESCRIPTION
This branch adds functionality to export the thruster explicitly. Now the user has to define the thruster he wants to export inside the <plugin> tag from the Gazebo model that contains the thrusters. The thruster name must be the same as the link name you want to use as thruster. This branch also creates the parameters: min_thrust and max_thrust to limit thrust values. 
